### PR TITLE
Permite selecionar o ideogramas arrastando o mouse

### DIFF
--- a/src/components/IdeogramCard/index.jsx
+++ b/src/components/IdeogramCard/index.jsx
@@ -1,8 +1,9 @@
-import { useRef } from "react"
 import "./style.css"
-import { useEffect } from "react"
+import { useEffect, useRef, useState } from "react"
 
-const IdeogramCard = ({ideogram, romanji, sizeDivision, selection, writingSystemKey, kanaKey, setKey, writingSystems, setWritingSystems}) => {
+const IdeogramCard = ({ideogram, romanji, sizeDivision, mouseDownStatus, selection, writingSystemKey, kanaKey, setKey, writingSystems, setWritingSystems}) => {
+    const [canSelect, setCanSelect] = useState(true)
+
     const ideogramCardRef = useRef()
 
     const setClickAnimation = () => {
@@ -34,9 +35,12 @@ const IdeogramCard = ({ideogram, romanji, sizeDivision, selection, writingSystem
         }))
     }
 
-    const handleClick = () => {
-        setClickAnimation()
-        setSelectionStatus()
+    const handleSelection = (e) => {
+        console.log(e.type)
+        if (e.type === "mousedown" || mouseDownStatus) {
+            setClickAnimation()
+            setSelectionStatus()
+        }
     }
 
     useEffect(() => {
@@ -52,7 +56,9 @@ const IdeogramCard = ({ideogram, romanji, sizeDivision, selection, writingSystem
         ref={ideogramCardRef}
         className="ideogram-card"
         style={{width: `calc(100% / ${sizeDivision} - 10px)`}}
-        onClick={handleClick}
+        
+        onMouseEnter={handleSelection}
+        onMouseDown={handleSelection}
         onAnimationEnd={removeClickAnimation}>
             <p className="ideogram">{ideogram}</p>
             <p className="romanji">{romanji}</p>

--- a/src/components/WritingSystemsDisplay/index.jsx
+++ b/src/components/WritingSystemsDisplay/index.jsx
@@ -1,9 +1,15 @@
+import { useEffect, useState } from "react"
 import IdeogramCard from "../IdeogramCard"
 
 import "./style.css"
 
 const WritingSystemsDisplay = ({writingSystems, setWritingSystems}) => {
-    
+    const [mouseDownStatus, setMouseDownStatus] = useState(false)
+
+    useEffect(() => {
+        document.addEventListener("mousedown", () => setMouseDownStatus(true))
+        document.addEventListener("mouseup", () => setMouseDownStatus(false))
+    }, [])
 
     return (
         <div className="writing-systems-display">
@@ -29,6 +35,7 @@ const WritingSystemsDisplay = ({writingSystems, setWritingSystems}) => {
                                         ideogram={item.ideogram}
                                         romanji={item.romanji}
                                         sizeDivision={writingSystems[writingSystemKey][kanaKey][setKey].length}
+                                        mouseDownStatus={mouseDownStatus}
                                         selection={item.selection}
                                         writingSystemKey={writingSystemKey}
                                         kanaKey={kanaKey}


### PR DESCRIPTION
Pode segurar o botão esquerdo do mouse e arrastar ele por cima dos IdeogramCards para selecionar os ideogramas.

Permite selecionar os ideogramas mais rapidamente.